### PR TITLE
Update rubocop and remove duplication of code

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,4 @@
+engines:
+  rubocop:
+    enabled: true
+    channel: rubocop-0-49

--- a/lib/wor/push/notifications/aws/ios_push_json_builder.rb
+++ b/lib/wor/push/notifications/aws/ios_push_json_builder.rb
@@ -6,13 +6,16 @@ module Wor
           class << self
             def build_json(message_content)
               unless Wor::Push::Notifications::Aws.aws_ios_sandbox
-                return { APNS:
-                  { aps: { alert: message_content[:message], badge: message_content[:badge],
-                           sound: 'default' } }.merge(message_content).to_json }
+                return { APNS: aps_content(message_content) }
               end
-              { APNS_SANDBOX:
-                { aps: { alert: message_content[:message], badge: message_content[:badge],
-                         sound: 'default' } }.merge(message_content).to_json }
+              { APNS_SANDBOX: aps_content(message_content) }
+            end
+
+            private
+
+            def aps_content(message_content)
+              { aps: { alert: message_content[:message], badge: message_content[:badge],
+                       sound: 'default' } }.merge(message_content).to_json
             end
           end
         end

--- a/wor-push-notifications-aws.gemspec
+++ b/wor-push-notifications-aws.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'rspec-rails', '~> 3.5'
   spec.add_development_dependency 'byebug', '~> 9.0'
-  spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'rubocop', '~> 0.49'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'
   spec.add_development_dependency 'generator_spec'
   spec.add_development_dependency 'simplecov'


### PR DESCRIPTION
### Summary
Update rubocop to the last version, add codeclimate configuration in order to match the same version of rubocop and removing duplicates.