### PR TITLE
Move gem dependencies to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,15 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in wor-push-notifications-aws.gemspec
 gemspec
+
+group :development do
+  gem 'bundler', '~> 1.13'
+  gem 'byebug', '~> 9.0'
+  gem 'codeclimate-test-reporter', '~> 1.0.0'
+  gem 'generator_spec'
+  gem 'rake', '~> 10.0'
+  gem 'rspec', '~> 3.0'
+  gem 'rspec-rails', '~> 3.5'
+  gem 'rubocop', '~> 0.48'
+  gem 'simplecov', '~> 0.13'
+end

--- a/wor-push-notifications-aws.gemspec
+++ b/wor-push-notifications-aws.gemspec
@@ -21,14 +21,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'railties', '>= 4.1.0', '< 5.2'
   spec.add_dependency 'aws-sdk-rails', "~> 1.0"
-
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency 'rspec-rails', '~> 3.5'
-  spec.add_development_dependency 'byebug', '~> 9.0'
-  spec.add_development_dependency 'rubocop', '~> 0.48'
-  spec.add_development_dependency 'codeclimate-test-reporter', '~> 1.0.0'
-  spec.add_development_dependency 'generator_spec'
-  spec.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
### Summary
In order not to force the people using the gem in development to have the development dependencies we move those dependencies from the gemspec to the gemfile.