### PR TITLE
Validates and converts message_content in hash with indifferent access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+Change log
+
+[0.1.2] - 2017-08-04
+
+- Adds validations for the `message_content`
+- Accepts `message_content` with Strings or Symbols as keys
+
+[0.1.1]
+
+- Fixes SNS::Client location
+
+[0.1.0]
+
+- wor-push-notifications-aws gem first release.

--- a/lib/wor/push/notifications/aws/push_notifications.rb
+++ b/lib/wor/push/notifications/aws/push_notifications.rb
@@ -31,8 +31,10 @@ module Wor
             end
 
             def send_message(user, message_content)
-              PushNotificationsValidator.new(user).validate_send_message(message_content)
-              message_content = badge_check(message_content)
+              PushNotificationsValidator.new(user).validate_model
+              message_content = PushNotificationsValidator.validate_message_content(
+                message_content
+              )
               send_notifications_to_user(user, message_content)
             end
 
@@ -82,11 +84,6 @@ module Wor
                   json_builder: AndroidPushJsonBuilder
                 }
               }
-            end
-
-            def badge_check(message_content)
-              message_content[:badge] = 1 if message_content[:badge].nil?
-              message_content
             end
           end
         end

--- a/lib/wor/push/notifications/aws/validators/push_notifications_validator.rb
+++ b/lib/wor/push/notifications/aws/validators/push_notifications_validator.rb
@@ -44,7 +44,7 @@ module Wor
             end
 
             def badge_check(message_content)
-              message_content[:badge] = 1 if message_content[:badge].nil?
+              message_content[:badge] ||= 1
               message_content
             end
           end

--- a/lib/wor/push/notifications/aws/validators/push_notifications_validator.rb
+++ b/lib/wor/push/notifications/aws/validators/push_notifications_validator.rb
@@ -20,10 +20,33 @@ module Wor
             validate_existence_of_attributes_in_model
           end
 
-          def validate_send_message(message_content)
+          def validate_model
             validate_model_existance
             validate_existence_of_attributes_in_model
-            validate_message_content(message_content)
+          end
+
+          class << self
+            def validate_message_content(message_content)
+              raise ArgumentError, message_content_type_error unless message_content.is_a?(Hash)
+              message_content = message_content.with_indifferent_access
+              raise ArgumentError, message_content_error if message_content[:message].blank?
+              badge_check(message_content)
+            end
+
+            private
+
+            def message_content_error
+              "the message_content must have a 'message' field"
+            end
+
+            def message_content_type_error
+              'message_content must be a Hash'
+            end
+
+            def badge_check(message_content)
+              message_content[:badge] = 1 if message_content[:badge].nil?
+              message_content
+            end
           end
 
           private
@@ -36,10 +59,6 @@ module Wor
             return if @model.has_attribute?(:device_tokens)
             raise Wor::Push::Notifications::Aws::Exceptions::ModelWithoutDeviceTokensAttribute,
                   message_for_missing_attribute_in_model
-          end
-
-          def validate_message_content(message_content)
-            raise ArgumentError, message_content_error_message if message_content[:message].blank?
           end
 
           def validate_parameters
@@ -62,10 +81,6 @@ module Wor
 
           def message_for_nil_model
             'your entity instance cannot be nil.'
-          end
-
-          def message_content_error_message
-            "the message_content must have a 'message' field"
           end
 
           def device_type_valid?

--- a/lib/wor/push/notifications/aws/version.rb
+++ b/lib/wor/push/notifications/aws/version.rb
@@ -2,7 +2,7 @@ module Wor
   module Push
     module Notifications
       module Aws
-        VERSION = '0.1.1'.freeze
+        VERSION = '0.1.2'.freeze
       end
     end
   end

--- a/spec/wor/push/notifications/push_notifications_spec.rb
+++ b/spec/wor/push/notifications/push_notifications_spec.rb
@@ -133,14 +133,6 @@ describe Wor::Push::Notifications::Aws::PushNotifications do
           send_message
         end
       end
-
-      context 'when passing a message_content that is not a Hash' do
-        let(:message_content) { [5, 'String'].sample }
-
-        it 'raises argument error with a descriptive message' do
-          expect { send_message }.to raise_error(ArgumentError, /message_content must be a Hash/)
-        end
-      end
     end
   end
 end

--- a/spec/wor/push/notifications/push_notifications_spec.rb
+++ b/spec/wor/push/notifications/push_notifications_spec.rb
@@ -85,7 +85,13 @@ describe Wor::Push::Notifications::Aws::PushNotifications do
 
     it 'validates the method' do
       expect_any_instance_of(Wor::Push::Notifications::Aws::PushNotificationsValidator)
-        .to receive(:validate_send_message)
+        .to receive(:validate_model)
+      send_message
+    end
+
+    it 'validates the message_content' do
+      expect(Wor::Push::Notifications::Aws::PushNotificationsValidator)
+        .to receive(:validate_message_content)
       send_message
     end
 
@@ -108,6 +114,32 @@ describe Wor::Push::Notifications::Aws::PushNotifications do
 
       it 'returns true' do
         expect(send_message).to be true
+      end
+
+      context 'when passing a message_content with symbols as keys' do
+        let(:message_content) { { message: 'A message' } }
+
+        it 'sends the message' do
+          expect_any_instance_of(SnsClientMock).to receive(:publish)
+          send_message
+        end
+      end
+
+      context 'when passing a hash with strings as keys' do
+        let(:message_content) { { 'message' => 'A message' } }
+
+        it 'sends the message' do
+          expect_any_instance_of(SnsClientMock).to receive(:publish)
+          send_message
+        end
+      end
+
+      context 'when passing a message_content that is not a Hash' do
+        let(:message_content) { [5, 'String'].sample }
+
+        it 'raises argument error with a descriptive message' do
+          expect { send_message }.to raise_error(ArgumentError, /message_content must be a Hash/)
+        end
       end
     end
   end

--- a/spec/wor/push/notifications/validators/push_notifications_validator_spec.rb
+++ b/spec/wor/push/notifications/validators/push_notifications_validator_spec.rb
@@ -100,50 +100,73 @@ describe Wor::Push::Notifications::Aws::PushNotificationsValidator do
     end
   end
 
-  describe '#validate_send_message' do
-    let(:validate_send_message) { subject.validate_send_message(message_content) }
+  describe '#validate_model' do
+    let(:validate_model) { subject.validate_model }
     let(:device_token) { nil }
     let(:device_type) { nil }
 
     context 'with valid parameters' do
-      let(:message_content) { { message: 'A message' } }
       let(:model) { UserWithDeviceTokensAttribute.new(user_mail) }
 
       it 'does not raise error' do
-        expect { validate_send_message }.not_to raise_error
+        expect { validate_model }.not_to raise_error
       end
     end
 
     context 'when the model is nil' do
       let(:model) { nil }
-      let(:message_content) { { other_field: 'some information' } }
 
       it 'raises runtime error with a descriptive message' do
-        expect { validate_send_message }.to raise_error(ArgumentError,
-                                                        /your entity instance cannot be nil./)
-      end
-    end
-
-    context 'with invalid message content' do
-      # Does not have 'message' field
-      let(:message_content) { { other_field: 'some information' } }
-      let(:model) { UserWithDeviceTokensAttribute.new(user_mail) }
-
-      it 'raises runtime error with a descriptive message' do
-        expect { validate_send_message }
-          .to raise_error(ArgumentError, /the message_content must have a 'message' field/)
+        expect { validate_model }.to raise_error(ArgumentError,
+                                                 /your entity instance cannot be nil./)
       end
     end
 
     context 'when the model does not have the device_tokens attribute' do
-      let(:message_content) { { message: 'A message' } }
       let(:model) { UserWithoutDeviceTokensAttribute.new(user_mail) }
 
       it 'raises runtime error with a descriptive message' do
-        expect { validate_send_message }.to raise_error(
+        expect { validate_model }.to raise_error(
           Wor::Push::Notifications::Aws::Exceptions::ModelWithoutDeviceTokensAttribute,
           /Missing attribute device_tokens/
         )
+      end
+    end
+  end
+
+  describe '.validate_message_content' do
+    let(:validate_message_content) { described_class.validate_message_content(message_content) }
+
+    context 'when passing a message_content without a badge field' do
+      let(:message_content) { { message: 'A message' } }
+
+      it 'adds the badge field' do
+        expect(validate_message_content[:badge]).to eq 1
+      end
+    end
+
+    context 'when passing a message_content with symbols as keys' do
+      let(:message_content) { { message: 'A message' } }
+
+      it 'does not raise error' do
+        expect { validate_message_content }.not_to raise_error
+      end
+    end
+
+    context 'when passing a message_content with strings as keys' do
+      let(:message_content) { { 'message' => 'A message' } }
+
+      it 'does not raise error' do
+        expect { validate_message_content }.not_to raise_error
+      end
+    end
+
+    context 'when passing a message_content that is not a Hash' do
+      let(:message_content) { [5, 'String'].sample }
+
+      it 'raises argument error with a descriptive message' do
+        expect { validate_message_content }
+          .to raise_error(ArgumentError, /message_content must be a Hash/)
       end
     end
   end


### PR DESCRIPTION
## Summary

The gem broke when you passed a `message_content` with strings as keys instead of symbols.

I divided the validation of the model and the message content in two parts because the message content validation got more complicated.

Now it validates that:

- The `message_content` is a Hash
- Converts the `message_content` in a HashWithIndifferentAccess so you can access the fields, it doesn't matter if it has symbols or String as keys.
- Moves the badge check validations from the PushNotifications class to the PushNotificationsValidator
- Modifies the tests to separate this logic testing